### PR TITLE
change loss.numpy()[0] to float(loss) to adapt 0D

### DIFF
--- a/CV/Effective Transformer-based Solution for RSNA Intracranial Hemorrhage Detection/easymia/trainer/trainer.py
+++ b/CV/Effective Transformer-based Solution for RSNA Intracranial Hemorrhage Detection/easymia/trainer/trainer.py
@@ -180,7 +180,7 @@ class Trainer(Evaluator):
                 lr_sche.step()
 
             self.recorder.record("batch_cost_time", time.time() - batch_start)
-            self.recorder.record("loss", loss.numpy()[0])
+            self.recorder.record("loss", float(loss))
             self.recorder.record("lr", current_lr)
 
             if iter % self.log_iters == 0 and local_rank == 0:

--- a/CV/PWCNet/train.py
+++ b/CV/PWCNet/train.py
@@ -113,7 +113,7 @@ def val(model, batch_reader, epoch, batch_num):
         network_output = model(im_all, output_more=False)
         loss = realEPE(network_output, label)
         end = time.time()
-        loss_cnt.update(loss.numpy()[0], step)
+        loss_cnt.update(float(loss), step)
         print('val epoch {} batch {}/{} run time: {}s read data time {}s loss {}'.format(epoch, batch_id, batch_num,
                                                                                      round(end - start, 2),
                                                                                      round(read_data_time, 2),

--- a/CV/SemSegPaddleDG/train.py
+++ b/CV/SemSegPaddleDG/train.py
@@ -290,7 +290,7 @@ def train(cfg):
                                                                epoch + 1,
                                                                during_time[:6],
                                                                batch_id + 1,
-                                                               train_avg_loss.numpy()[0],
+                                                               float(train_avg_loss),
                                                                lr)
                 
                 if batch_id % 100 == 0:
@@ -334,7 +334,7 @@ def train(cfg):
                     print('Validation trained_id:{}, epoch:{}, batch_id:{}, time:{}s, val_loss:{}.'.format(train_id, epoch+1,
                                                                                                             batch_id,
                                                                                                             during_time[:6],
-                                                                                                            val_avg_loss.numpy()[0],
+                                                                                                            float(val_avg_loss),
                                                                                                             ))
             acc, acc_cls, iu, mean_iu_val, fwavacc, kappa = val_iou_np.evaluate()
             print('Validation epoch:{}, val_loss{}, val_iou_np:{}'.format(epoch+1, test_avg_loss_manager.eval()[0], mean_iu_val))

--- a/ST_DM/CIKM2022-DuMapper/DME/engine/trainer.py
+++ b/ST_DM/CIKM2022-DuMapper/DME/engine/trainer.py
@@ -187,7 +187,7 @@ class Trainer(object):
                             embedding=list(embeddings.detach().cpu()[num].numpy())
                             embedding=[str(x) for x in embedding]
                             content.extend([' '.join(embedding)])
-                            x_norm = str(embeddings_norm.detach().cpu()[num].numpy()[0])
+                            x_norm = str(float(embeddings_norm.detach().cpu()[num]))
                             content.append(x_norm)
                             content='\t'.join(content)
                             f.write(content + '\n') 


### PR DESCRIPTION
loss正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在进行升级为0D后，loss.numpy()[0] 的写法不再使用，将其改变为 float(loss) 的写法，在升级前(shape为[1])、升级后(shape为[])下都同样适用，兼容改法。